### PR TITLE
Update nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Rust wrappers for libfdisk"
 libc = "0.2"
 error-chain = { version = "0.12", default-features = false }
 libfdisk-sys = "0.1"
-nix = "0.21"
+nix = "0.24"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/context.rs
+++ b/src/context.rs
@@ -60,7 +60,7 @@ impl Context {
             libfdisk_sys::fdisk_assign_device(self.ptr, device.as_ptr(), readonly as i32)
         } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -71,7 +71,7 @@ impl Context {
     pub fn deassign_device(&self, nosync: bool) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_deassign_device(self.ptr, nosync as i32) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -81,7 +81,7 @@ impl Context {
     pub fn enable_wipe(&self, enable: bool) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_enable_wipe(self.ptr, enable as i32) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -92,7 +92,7 @@ impl Context {
     pub fn enable_bootbits_protection(&self, enable: bool) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_enable_bootbits_protection(self.ptr, enable as i32) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -103,7 +103,7 @@ impl Context {
     pub fn enable_details(&self, enable: bool) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_enable_details(self.ptr, enable as i32) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -113,7 +113,7 @@ impl Context {
     pub fn enable_listonly(&self, enable: bool) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_enable_listonly(self.ptr, enable as i32) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -216,7 +216,7 @@ impl Context {
         let mut table = Table::new();
         match unsafe { libfdisk_sys::fdisk_get_partitions(self.ptr, &mut table.ptr) } {
             0 => Ok(table),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -313,7 +313,7 @@ impl Context {
     pub fn set_size_unit(&self, unit: DiskUnit) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_set_size_unit(self.ptr, unit as i32) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -328,7 +328,7 @@ impl Context {
         };
         match unsafe { libfdisk_sys::fdisk_set_unit(self.ptr, s.as_ptr()) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -345,7 +345,7 @@ impl Context {
     pub fn save_user_sector_size(&self, phy: u32, log: u32) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_save_user_sector_size(self.ptr, phy, log) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -75,7 +75,7 @@ impl Context {
         let name = CString::new(name.as_ref().as_bytes())?;
         match unsafe { libfdisk_sys::fdisk_create_disklabel(self.ptr, name.as_ptr()) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -83,7 +83,7 @@ impl Context {
     pub fn write_disklabel(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_write_disklabel(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -91,7 +91,7 @@ impl Context {
     pub fn verify_disklabel(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_verify_disklabel(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -70,7 +70,7 @@ impl Partition {
         let mut p: usize = 0;
         match unsafe { libfdisk_sys::fdisk_partition_get_parent(self.ptr, &mut p) } {
             0 => Ok(p),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(v)).into()),
+            v => Err(nix::errno::from_i32(v).into()),
         }
     }
 
@@ -145,21 +145,21 @@ impl Partition {
     pub fn set_partno(&self, partno: usize) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_partition_set_partno(self.ptr, partno) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
     pub fn set_size(&self, size: u64) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_partition_set_size(self.ptr, size) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
     pub fn set_start(&self, start: u64) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_partition_set_start(self.ptr, start) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -167,7 +167,7 @@ impl Partition {
         let attrs = CString::new(attrs.as_bytes())?;
         match unsafe { libfdisk_sys::fdisk_partition_set_attrs(self.ptr, attrs.as_ptr()) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -175,7 +175,7 @@ impl Partition {
         let name = CString::new(name.as_bytes())?;
         match unsafe { libfdisk_sys::fdisk_partition_set_name(self.ptr, name.as_ptr()) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -183,7 +183,7 @@ impl Partition {
         let uuid = CString::new(uuid.as_bytes())?;
         match unsafe { libfdisk_sys::fdisk_partition_set_uuid(self.ptr, uuid.as_ptr()) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -194,7 +194,7 @@ impl Partition {
             libfdisk_sys::fdisk_partition_size_explicit(self.ptr, if enable { 1 } else { 0 })
         } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -204,7 +204,7 @@ impl Partition {
             libfdisk_sys::fdisk_partition_start_follow_default(self.ptr, if enable { 1 } else { 0 })
         } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -217,7 +217,7 @@ impl Partition {
     pub fn unset_partno(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_partition_unset_partno(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -225,7 +225,7 @@ impl Partition {
     pub fn unset_size(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_partition_unset_size(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -233,7 +233,7 @@ impl Partition {
     pub fn unset_start(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_partition_unset_start(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 }
@@ -258,7 +258,7 @@ impl Context {
     pub fn set_partition(&self, no: usize, pt: &Partition) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_set_partition(self.ptr, no, pt.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -266,7 +266,7 @@ impl Context {
     pub fn delete_all_partitions(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_delete_all_partitions(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -276,7 +276,7 @@ impl Context {
     pub fn delete_partition(&self, no: usize) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_delete_partition(self.ptr, no) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -31,7 +31,7 @@ impl Table {
     pub fn reset_table(&self) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_reset_table(self.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -43,7 +43,7 @@ impl Table {
     pub fn add_partition(&self, pa: &mut Partition) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_table_add_partition(self.ptr, pa.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -84,7 +84,7 @@ impl Table {
     pub fn remove_partition(&self, pa: &mut Partition) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_table_remove_partition(self.ptr, pa.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 
@@ -123,7 +123,7 @@ impl Context {
     pub fn apply_table(&self, table: &Table) -> Result<()> {
         match unsafe { libfdisk_sys::fdisk_apply_table(self.ptr, table.ptr) } {
             0 => Ok(()),
-            v => Err(nix::Error::from_errno(nix::errno::from_i32(-v)).into()),
+            v => Err(nix::errno::from_i32(-v).into()),
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,196 @@
+use serde::Deserialize;
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+use libfdisk::context::Context;
+use libfdisk::label::DiskLabel;
+
+const DEFAULT_TYPE: &str = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
+const DEFAULT_GPT_LBA: u64 = 34;
+
+#[derive(Debug, Deserialize)]
+struct SFdiskDump {
+    #[serde(rename = "partitiontable")]
+    partition_table: SFdiskPartitionTable,
+}
+
+#[derive(Debug, Deserialize)]
+struct SFdiskPartitionTable {
+    label: String,
+    id: String,
+    device: String,
+    unit: String,
+    #[serde(rename = "firstlba")]
+    first_lba: u64,
+    #[serde(rename = "lastlba")]
+    last_lba: u64,
+    grain: String,
+    #[serde(rename = "sectorsize")]
+    sector_size: u32,
+    partitions: Option<Vec<SFdiskPartition>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SFdiskPartition {
+    node: String,
+    start: u64,
+    size: u64,
+    #[serde(rename = "type")]
+    _type: String,
+    uuid: String,
+}
+
+fn sfdisk_dump(path: &std::path::Path) -> std::io::Result<SFdiskDump> {
+    let result = Command::new("/usr/sbin/sfdisk")
+        .args(["--json", "--dump", path.to_str().unwrap()])
+        .output()?;
+    let stdout = std::str::from_utf8(&result.stdout).unwrap();
+
+    let out: SFdiskDump = serde_json::from_str(&stdout)?;
+    Ok(out)
+}
+
+fn create_file() -> std::path::PathBuf {
+    let file = NamedTempFile::new().unwrap();
+    let (mut file2, path) = file.keep().unwrap();
+    // let mut file3 = file2.open().unwrap();
+    let zeros = vec![0; 65528];
+    file2.write_all(&zeros).unwrap();
+    path
+}
+
+#[test]
+fn create_gpt_label() {
+    let path = create_file();
+
+    let context = Context::new();
+    context.assign_device(&path, false).unwrap();
+    context.create_disklabel(DiskLabel::Gpt).unwrap();
+    context.write_disklabel().unwrap();
+    context.deassign_device(false).unwrap();
+
+    let label = context.get_label("").unwrap();
+    assert_eq!("gpt", label.get_name().unwrap());
+
+    let result = sfdisk_dump(&path).unwrap();
+
+    assert_eq!("gpt", result.partition_table.label)
+}
+
+#[test]
+fn create_a_single_partition() {
+    let path = create_file();
+
+    let context = Context::new();
+    context.assign_device(&path, false).unwrap();
+    context.create_disklabel(DiskLabel::Gpt).unwrap();
+
+    let partition = libfdisk::Partition::new();
+    partition.set_start(context.first_lba()).unwrap();
+    partition
+        .set_size(context.last_lba() - context.first_lba() + 1)
+        .unwrap();
+    partition.set_partno(0).unwrap();
+    context.set_partition(0, &partition).unwrap();
+
+    context.write_disklabel().unwrap();
+    context.deassign_device(false).unwrap();
+
+    let dump = sfdisk_dump(&path).unwrap();
+
+    let parts = dump.partition_table.partitions.unwrap();
+    let first_part = parts.get(0).unwrap();
+
+    assert_eq!(DEFAULT_GPT_LBA, first_part.start);
+    assert_eq!(60, first_part.size);
+    assert_eq!(DEFAULT_TYPE, first_part._type)
+}
+
+#[test]
+fn delete_all_partitions() {
+    let path = create_file();
+
+    let context = Context::new();
+    context.assign_device(&path, false).unwrap();
+    context.create_disklabel(DiskLabel::Gpt).unwrap();
+
+    let partition = libfdisk::Partition::new();
+    partition.set_start(context.first_lba()).unwrap();
+    partition.set_size(10).unwrap();
+    partition.set_partno(0).unwrap();
+    context.set_partition(0, &partition).unwrap();
+
+    context.delete_all_partitions().unwrap();
+
+    context.write_disklabel().unwrap();
+    context.deassign_device(false).unwrap();
+
+    let dump = sfdisk_dump(&path).unwrap();
+
+    assert!(dump.partition_table.partitions.is_none())
+}
+
+#[test]
+fn delete_a_partition() {
+    let path = create_file();
+
+    let context = Context::new();
+    context.assign_device(&path, false).unwrap();
+    context.create_disklabel(DiskLabel::Gpt).unwrap();
+
+    let partition = libfdisk::Partition::new();
+    partition.set_start(context.first_lba()).unwrap();
+    partition.set_size(10).unwrap();
+    partition.set_partno(0).unwrap();
+    context.set_partition(0, &partition).unwrap();
+
+    context.delete_partition(0).unwrap();
+
+    context.write_disklabel().unwrap();
+    context.deassign_device(false).unwrap();
+
+    let dump = sfdisk_dump(&path).unwrap();
+
+    assert!(dump.partition_table.partitions.is_none())
+}
+
+#[test]
+fn cannot_set_size_bigger_then_lba() {
+    let path = create_file();
+
+    let context = Context::new();
+    context.assign_device(&path, false).unwrap();
+    context.create_disklabel(DiskLabel::Gpt).unwrap();
+
+    let partition = libfdisk::Partition::new();
+    partition.set_start(context.first_lba()).unwrap();
+    partition.set_size(1000).unwrap();
+    assert!(context.set_partition(0, &partition).is_err())
+}
+
+#[test]
+fn use_table() {
+    let path = create_file();
+
+    let context = Context::new();
+    context.assign_device(&path, false).unwrap();
+    context.create_disklabel(DiskLabel::Gpt).unwrap();
+
+    let table = context.get_partitions().unwrap();
+    let mut partition = libfdisk::Partition::new();
+    partition.set_start(context.first_lba()).unwrap();
+    partition.set_size(10).unwrap();
+    partition.set_partno(0).unwrap();
+    table.add_partition(&mut partition).unwrap();
+
+    assert_eq!(1, table.nents());
+
+    context.apply_table(&table).unwrap();
+    context.write_disklabel().unwrap();
+    context.deassign_device(false).unwrap();
+
+    let dump = sfdisk_dump(&path).unwrap();
+
+    assert!(!dump.partition_table.partitions.is_none())
+}


### PR DESCRIPTION
* Update nix from `0.21` to `0.24`. This has no impact on the lib, it stay backward compatible. Nix is only used for error with `errno`.